### PR TITLE
Add a script to run grist

### DIFF
--- a/docker/grist/docker.run.sh
+++ b/docker/grist/docker.run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+pushd /mnt/y/nextcloud/rg-all/docker/
+
+docker run \
+    --rm \
+    \
+    -p 8484:8484 \
+    \
+    -v $PWD/grist/persist:/persist \
+    \
+    -it \
+    \
+    gristlabs/grist
+
+popd


### PR DESCRIPTION
This patch adds a script to locally run grist inside the default docker container.
You can run the script from everywhere inside WSL.